### PR TITLE
clean up implementation a bit

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -39,9 +39,9 @@ class PhpCsFixer(Linter):
         'selector': 'embedding.php, source.php, text.html.basic'
     }
     regex = (
-        r'^\s+\d+\)\s+.+\s+\((?P<message>.+)\)[^\@]*'
+        r'^\s+\d+\)\s+.+\s+\((?P<error>.+)\)[^\@]*'
         r'\@\@\s+\-\d+,\d+\s+\+(?P<line>\d+),\d+\s+\@\@'
-        r'[^-+]+[-+]?\s+(?P<error>[^\n]*)'
+        r'[^-+]+[-+]?\s+(?P<message>[^\n]*)'
     )
     multiline = True
     tempfile_suffix = 'php'
@@ -52,7 +52,6 @@ class PhpCsFixer(Linter):
         match, line, col, error, warning, message, near = super().split_match(match)
 
         line = line + 3
-        message = "php-cs-fixer error(s) - " + message
 
         return match, line, col, error, warning, message, near
 

--- a/linter.py
+++ b/linter.py
@@ -63,7 +63,7 @@ class PhpCsFixer(Linter):
         command.append('--show-progress=none')
         command.append('--stop-on-violation')
 
-        if self.settings.get('version') and self.settings.get('version') == 2:
+        if self.settings.get('version') == 2:
             command.append('--diff-format=udiff')
         else:
             command.append('--diff')

--- a/linter.py
+++ b/linter.py
@@ -8,13 +8,7 @@ logger = logging.getLogger('SublimeLinter.plugin.php-cs-fixer')
 
 
 def find_configuration_file(file_name):
-    if file_name is None:
-        return None
-
-    if not isinstance(file_name, str):
-        return None
-
-    if not len(file_name) > 0:
+    if not file_name:
         return None
 
     checked = []

--- a/linter.py
+++ b/linter.py
@@ -1,15 +1,3 @@
-#
-# linter.py
-# Linter for SublimeLinter3, a code checking framework for Sublime Text 3
-#
-# Written by Jordan Hoff
-# Copyright (c) 2017 Jordan Hoff
-#
-# License: MIT
-#
-
-"""This module exports the PhpCsFixer plugin class."""
-
 import logging
 import os
 

--- a/linter.py
+++ b/linter.py
@@ -43,27 +43,21 @@ class PhpCsFixer(Linter):
     line_col_base = (-2, 1)
 
     def cmd(self):
-        """Read cmd from inline settings."""
-        command = ['php-cs-fixer']
-        command.append('fix')
-        command.append('${temp_file}')
-        command.append('--dry-run')
-        command.append('--show-progress=none')
-        command.append('--stop-on-violation')
+       command = [
+           'php-cs-fixer',
+           'fix',
+           '${temp_file}',
+           '--dry-run',
+           '--show-progress=none',
+           '--stop-on-violation',
+           '--diff-format=udiff' if self.settings.get('version') == 2 else '--diff',
+           '--using-cache=no',
+           '--no-ansi',
+           '-vv'
+       ]
 
-        if self.settings.get('version') == 2:
-            command.append('--diff-format=udiff')
-        else:
-            command.append('--diff')
-
-        command.append('--using-cache=no')
-        command.append('--no-ansi')
-        command.append('-vv')
-
-        config_file = self.settings.get('config_file')
-        if not config_file:
-            config_file = find_configuration_file(self.view.file_name())
-        if config_file:
-            command.append('--config=' + config_file)
+       config_file = self.settings.get('config_file') or find_configuration_file(self.view.file_name())
+       if config_file:
+           command.append(f'--config={config_file}')
 
         return command

--- a/linter.py
+++ b/linter.py
@@ -39,9 +39,9 @@ class PhpCsFixer(Linter):
         'selector': 'embedding.php, source.php, text.html.basic'
     }
     regex = (
-        r'^\s+\d+\)\s+.+\s+\((?P<error>.+)\)[^\@]*'
+        r'^\s+\d+\)\s+.+\s+\((?P<message>.+)\)[^\@]*'
         r'\@\@\s+\-\d+,\d+\s+\+(?P<line>\d+),\d+\s+\@\@'
-        r'[^-+]+[-+]?\s+(?P<message>[^\n]*)'
+        r'[^-+]+[-+]?\s+[^\n]*'
     )
     multiline = True
     tempfile_suffix = 'php'

--- a/linter.py
+++ b/linter.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 from SublimeLinter.lint import Linter, util
 
@@ -11,18 +12,13 @@ def find_configuration_file(file_name):
     if not file_name:
         return None
 
-    checked = []
-    check_dir = os.path.dirname(file_name)
     candidates = ['.php-cs-fixer.php', '.php-cs-fixer.dist.php', '.php_cs', '.php_cs.dist']
-    while check_dir not in checked:
+    for parent in Path(file_name).parents:
         for candidate in candidates:
-            configuration_file = os.path.join(check_dir, candidate)
-            if os.path.isfile(configuration_file):
+            configuration_file = parent / candidate
+            if configuration_file.is_file():
                 return configuration_file
-
-        checked.append(check_dir)
-        check_dir = os.path.dirname(check_dir)
-
+    
     return None
 
 

--- a/linter.py
+++ b/linter.py
@@ -46,14 +46,7 @@ class PhpCsFixer(Linter):
     multiline = True
     tempfile_suffix = 'php'
     error_stream = util.STREAM_STDOUT
-
-    def split_match(self, match):
-        """Extract and return values from match."""
-        match, line, col, error, warning, message, near = super().split_match(match)
-
-        line = line + 3
-
-        return match, line, col, error, warning, message, near
+    line_col_base = (-2, 1)
 
     def cmd(self):
         """Read cmd from inline settings."""

--- a/linter.py
+++ b/linter.py
@@ -1,5 +1,3 @@
-import logging
-import os
 from pathlib import Path
 
 from SublimeLinter.lint import ComposerLinter, util
@@ -15,7 +13,7 @@ def find_configuration_file(file_name):
             configuration_file = parent / candidate
             if configuration_file.is_file():
                 return configuration_file
-    
+
     return None
 
 
@@ -36,21 +34,21 @@ class PhpCsFixer(ComposerLinter):
     line_col_base = (-2, 1)
 
     def cmd(self):
-       command = [
-           'php-cs-fixer',
-           'fix',
-           '${temp_file}',
-           '--dry-run',
-           '--show-progress=none',
-           '--stop-on-violation',
-           '--diff-format=udiff' if self.settings.get('version') == 2 else '--diff',
-           '--using-cache=no',
-           '--no-ansi',
-           '-vv'
-       ]
+        command = [
+            'php-cs-fixer',
+            'fix',
+            '${temp_file}',
+            '--dry-run',
+            '--show-progress=none',
+            '--stop-on-violation',
+            '--diff-format=udiff' if self.settings.get('version') == 2 else '--diff',
+            '--using-cache=no',
+            '--no-ansi',
+            '-vv'
+        ]
 
-       config_file = self.settings.get('config_file') or find_configuration_file(self.view.file_name())
-       if config_file:
-           command.append(f'--config={config_file}')
+        config_file = self.settings.get('config_file') or find_configuration_file(self.view.file_name())
+        if config_file:
+            command.append(f'--config={config_file}')
 
         return command

--- a/linter.py
+++ b/linter.py
@@ -5,9 +5,6 @@ from pathlib import Path
 from SublimeLinter.lint import Linter, util
 
 
-logger = logging.getLogger('SublimeLinter.plugin.php-cs-fixer')
-
-
 def find_configuration_file(file_name):
     if not file_name:
         return None

--- a/linter.py
+++ b/linter.py
@@ -7,7 +7,7 @@ from SublimeLinter.lint import Linter, util
 logger = logging.getLogger('SublimeLinter.plugin.php-cs-fixer')
 
 
-def _find_configuration_file(file_name):
+def find_configuration_file(file_name):
     if file_name is None:
         return None
 
@@ -68,7 +68,7 @@ class PhpCsFixer(Linter):
         if 'config_file' in self.settings:
             config_file = self.settings.get('config_file')
         else:
-            config_file = _find_configuration_file(self.view.file_name())
+            config_file = find_configuration_file(self.view.file_name())
             if not config_file:
                 config_file = self.config_file
 

--- a/linter.py
+++ b/linter.py
@@ -57,13 +57,6 @@ class PhpCsFixer(Linter):
         else:
             command = ['php-cs-fixer']
 
-        if 'config_file' in self.settings:
-            config_file = self.settings.get('config_file')
-        else:
-            config_file = find_configuration_file(self.view.file_name())
-            if not config_file:
-                config_file = self.config_file
-
         command.append('fix')
         command.append('${temp_file}')
         command.append('--dry-run')
@@ -78,6 +71,11 @@ class PhpCsFixer(Linter):
         command.append('--using-cache=no')
         command.append('--no-ansi')
         command.append('-vv')
-        command.append('--config=' + config_file)
+
+        config_file = self.settings.get('config_file')
+        if not config_file:
+            config_file = find_configuration_file(self.view.file_name())
+        if config_file:
+            command.append('--config=' + config_file)
 
         return command

--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ import logging
 import os
 from pathlib import Path
 
-from SublimeLinter.lint import Linter, util
+from SublimeLinter.lint import ComposerLinter, util
 
 
 def find_configuration_file(file_name):
@@ -19,7 +19,7 @@ def find_configuration_file(file_name):
     return None
 
 
-class PhpCsFixer(Linter):
+class PhpCsFixer(ComposerLinter):
     """Provides an interface to php-cs-fixer."""
 
     defaults = {

--- a/linter.py
+++ b/linter.py
@@ -44,13 +44,7 @@ class PhpCsFixer(Linter):
 
     def cmd(self):
         """Read cmd from inline settings."""
-        if 'cmd' in self.settings:
-            logger.warning('The setting `cmd` has been deprecated. '
-                           'Use `executable` instead.')
-            command = [self.settings.get('cmd')]
-        else:
-            command = ['php-cs-fixer']
-
+        command = ['php-cs-fixer']
         command.append('fix')
         command.append('${temp_file}')
         command.append('--dry-run')


### PR DESCRIPTION
The implementation is a bit weird on several levels. The default output of this linter is a diff, and the plugin implementation badly fails at parsing it: the message is actually a list of error codes, and the message is some random code that might be near the error but is likely to be unrelated. Also, the errors are not clearly reported by line.

<img width="655" alt="Screenshot 2025-02-06 at 21 54 51" src="https://github.com/user-attachments/assets/547f01d1-ca10-4a28-b88b-34aed2a6e065" />

Looks like (perhaps recent, ie. somewhere in the past 8 years...) this linter supports output in various formats like JSON.

~@kaste the docs point to eslint as an example of implementing `find_errors`, but instead it implements `parse_output` for that. Is that still a good example?~

Edit: oh, never mind... most of the other formats are incapable of reporting the correct line of the errors... I get why that is though, it's really intended as a fixer (hence the name) and not a linter. So perhaps the current regex implementation is ok, since it is capable of finding the line of the first error, as well as the error codes, and none of the other formats actually have any more info (in fact they have less).